### PR TITLE
LM-55 Prevent double audio playback

### DIFF
--- a/src/components/IntroductionGame.vue
+++ b/src/components/IntroductionGame.vue
@@ -27,6 +27,7 @@ export default {
     return {
       badgeIndex: 0,
       puzzleIndex: 0,
+      hintAudio: new Audio(require(`../assets/introduce_game/instructions/0.mp3`)),
       gameStarted: false,
       getHelpButtonImage: require('../assets/help.svg'),
       cooldownTimeMiliseconds: 1000,
@@ -84,10 +85,16 @@ export default {
       } else {
         this.puzzleIndex = randomIndex
         this.solutions = randomIndex
+
+        this.hintAudio.pause()
+        this.hintAudio = new Audio(require(`../assets/introduce_game/instructions/${this.puzzleIndex}.mp3`))
       }
     },
     playInstruction(delay=0){
-      setTimeout(() => {new Audio(require(`../assets/introduce_game/instructions/${this.puzzleIndex}.mp3`)).play()},delay)
+      setTimeout(() => {
+        this.hintAudio.pause()
+        this.hintAudio.play()
+      },delay)
     },
     enableGame(delay) {
       setTimeout(() => {this.gameStarted = true},delay)

--- a/src/components/generic/GameTemplate.vue
+++ b/src/components/generic/GameTemplate.vue
@@ -35,6 +35,9 @@ export default {
       puzzleIndex: 0,
       getHelpButtonImage: require('../../assets/help.svg'),
       cooldownTimeMiliseconds: 1000,
+      hintAudio: this.seperateInstructions ? 
+        new Audio(require(`../../assets/${this.gameName.toLowerCase()}/instructions/${this.puzzleIndex ?? 0}.mp3`)) : 
+        new Audio(require(`../../assets/${this.gameName.toLowerCase()}/instruction.mp3`)),
       showPuzzle: true,
       firstPuzzle: true,
       date: Date.now() + this.audioDuration
@@ -70,13 +73,14 @@ export default {
   methods: {
     ...mapActions(useMainStore, ['postGameSetup']),
     playInstruction(){
-      if (this.seperateInstructions) {
-        new Audio(require(`../../assets/${this.gamePath}/instructions/${this.puzzleIndex}.mp3`)).play()
-      } else {
-        new Audio(require(`../../assets/${this.gamePath}/instruction.mp3`)).play()
-        }
+      if(this.hintAudio.currentTime != 0) {
+        this.hintAudio.pause()
+        this.hintAudio.currentTime = 0
+      }
+      this.hintAudio.play()
     },
     playTransition(){
+      this.hintAudio.pause()
       new Audio(require(`../../assets/${this.gamePath}/transition.mp3`)).play()
     },
     evalSelection(givenSolution) {
@@ -87,6 +91,10 @@ export default {
         }
         if (this.puzzleIndex < this.solutions.length) {
           this.puzzleIndex++;
+          if(this.seperateInstructions) {
+            this.hintAudio.pause()
+            this.hintAudio = new Audio(require(`../../assets/${this.gameName.toLowerCase()}/instructions/${this.puzzleIndex}.mp3`))
+          }
         }
         if (this.puzzleIndex === this.solutions.length) {
           this.postGameSetup({'name':this.gameName, 'level':this.badgeIndex})


### PR DESCRIPTION
The hint audio was able to be played back multiple times without stopping the previous one. This created noise if a user would be impacient or accidentially double press the hint button.